### PR TITLE
Add .yaml to graphql config name

### DIFF
--- a/content/GraphQL-Binding/04-Creating-your-own-Binding.md
+++ b/content/GraphQL-Binding/04-Creating-your-own-Binding.md
@@ -141,7 +141,7 @@ graphql-binding \
 
 For convenience, you can achieve the same by using the `codegen` command from the GraphQL CLI in combination with a `.graphqlconfig` file.
 
-Assuming you have the following `.graphqlconfig` file available in your project:
+Assuming you have the following `.graphqlconfig.yaml` file available in your project:
 
 ```yaml
 projects:


### PR DESCRIPTION
`graphql codegen` does not work without the .yaml prefix